### PR TITLE
fix: theme switching flashes

### DIFF
--- a/src/logics/index.ts
+++ b/src/logics/index.ts
@@ -39,6 +39,7 @@ export function toggleDark(event: MouseEvent) {
         {
           duration: 400,
           easing: 'ease-out',
+          fill: 'forwards',
           pseudoElement: isDark.value
             ? '::view-transition-old(root)'
             : '::view-transition-new(root)',


### PR DESCRIPTION
### Description

It flashes when switching from light to dark theme.

### Additional context

> before

[before.webm](https://github.com/user-attachments/assets/b757128c-a382-4482-90e5-abbd28483acb)

> after

[after.webm](https://github.com/user-attachments/assets/2ed09bb6-a1eb-4167-9db0-f76958b071b7)
